### PR TITLE
feat: add keyboard navigation to sound grid

### DIFF
--- a/components/sound-detail-page.tsx
+++ b/components/sound-detail-page.tsx
@@ -24,6 +24,7 @@ import { useSoundPlayback, type PlayState } from "@/hooks/use-sound-playback";
 import { useSoundDownload } from "@/hooks/use-sound-download";
 import { usePackageManager } from "@/hooks/use-package-manager";
 import { useHoverPreview } from "@/hooks/use-hover-preview";
+import { useGridNavigation } from "@/hooks/use-grid-navigation";
 import { cn } from "@/lib/utils";
 
 /* ── Waveform generation (pure, deterministic) ── */
@@ -332,6 +333,7 @@ export function SoundDetailPage({ sound, relatedSounds }: SoundDetailPageProps) 
   const { playState, toggle } = useSoundPlayback(sound.name);
   const download = useSoundDownload(sound.name);
   const { onPreviewStart, onPreviewStop } = useHoverPreview();
+  const { gridRef: relatedGridRef, onKeyDown: relatedKeyDown } = useGridNavigation();
 
   const snippets = useMemo(
     () => getSoundSnippets(sound.name, pm),
@@ -458,7 +460,13 @@ export function SoundDetailPage({ sound, relatedSounds }: SoundDetailPageProps) 
                 View all
               </Link>
             </div>
-            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+            <div
+              ref={relatedGridRef}
+              onKeyDown={relatedKeyDown}
+              role="grid"
+              aria-label="Related sounds"
+              className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4"
+            >
               {relatedSounds.map((s) => (
                 <RelatedSoundCard
                   key={s.name}

--- a/components/sound-grid.tsx
+++ b/components/sound-grid.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import type { SoundCatalogItem } from "@/lib/sound-catalog";
 import { SoundCard } from "@/components/sound-card";
+import { useGridNavigation } from "@/hooks/use-grid-navigation";
 
 interface SoundGridProps {
   sounds: SoundCatalogItem[];
@@ -11,6 +12,7 @@ interface SoundGridProps {
   onPreviewStart: (soundName: string) => void;
   onPreviewStop: () => void;
   onClearFilters?: () => void;
+  focusRef?: React.MutableRefObject<(() => void) | null>;
 }
 
 const EMPTY_EQ = [35, 55, 25, 70, 40, 60, 30];
@@ -24,7 +26,14 @@ export const SoundGrid = memo(function SoundGrid({
   onPreviewStart,
   onPreviewStop,
   onClearFilters,
+  focusRef,
 }: SoundGridProps) {
+  const { gridRef, onKeyDown, focusFirst } = useGridNavigation();
+
+  if (focusRef) {
+    focusRef.current = focusFirst;
+  }
+
   if (sounds.length === 0) {
     return (
       <div className="border-border/40 text-muted-foreground rounded-xl border border-dashed px-6 py-20 text-center">
@@ -54,7 +63,13 @@ export const SoundGrid = memo(function SoundGrid({
   }
 
   return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+    <div
+      ref={gridRef}
+      role="grid"
+      aria-label="Sound library"
+      onKeyDown={onKeyDown}
+      className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
+    >
       {sounds.map((sound) => (
         <SoundCard
           key={sound.name}

--- a/components/sound-search.tsx
+++ b/components/sound-search.tsx
@@ -6,9 +6,10 @@ import { Search } from "lucide-react";
 interface SoundSearchProps {
   value: string;
   onChange: (value: string) => void;
+  onEnterGrid?: () => void;
 }
 
-export function SoundSearch({ value, onChange }: SoundSearchProps) {
+export function SoundSearch({ value, onChange, onEnterGrid }: SoundSearchProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -37,6 +38,12 @@ export function SoundSearch({ value, onChange }: SoundSearchProps) {
         placeholder="Search sounds\u2026"
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            onEnterGrid?.();
+          }
+        }}
         className="border-border/60 bg-secondary/40 placeholder:text-muted-foreground/50 h-10 w-full rounded-lg border pl-9 pr-14 text-sm outline-none transition-[color,border-color,box-shadow,background-color] focus-visible:ring-[3px] focus-visible:ring-primary/20 focus-visible:border-primary/40 focus-visible:shadow-lg focus-visible:shadow-primary/15"
       />
       <kbd className="text-muted-foreground/40 pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 font-mono text-[11px]">

--- a/components/sounds-page.tsx
+++ b/components/sounds-page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { useQueryState, parseAsString } from "nuqs";
-import { Check,  Github, ListChecks, Package } from "lucide-react";
+import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Check, Github, ListChecks, Package } from "lucide-react";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { ALL_CATEGORY, type SoundCatalogItem } from "@/lib/sound-catalog";
 import { filterSounds, buildCategoryOptions } from "@/lib/sound-filters";
@@ -189,6 +189,8 @@ export function SoundsPage({ sounds }: SoundsPageProps) {
     [sounds]
   );
 
+  const gridFocusRef = useRef<(() => void) | null>(null);
+
   const { onPreviewStart, onPreviewStop } = useHoverPreview();
 
   const handleSelect = useCallback(
@@ -335,7 +337,7 @@ export function SoundsPage({ sounds }: SoundsPageProps) {
         style={{ animationDelay: "200ms" }}
       >
         <div className="mx-auto flex w-full max-w-6xl items-center gap-3 px-6 py-3">
-          <SoundSearch value={query} onChange={setQuery} />
+          <SoundSearch value={query} onChange={setQuery} onEnterGrid={() => gridFocusRef.current?.()} />
           <div className="min-w-0 flex-1">
             <CategoryFilter
               options={categoryOptions}
@@ -361,11 +363,21 @@ export function SoundsPage({ sounds }: SoundsPageProps) {
             {deferredSounds.length !== 1 ? "s" : ""}
           </p>
 
-          {/* Select mode hint */}
-          <p className="text-muted-foreground/60 text-xs hidden sm:flex items-center gap-1.5">
-            <ListChecks className="size-3.5" />
-            <kbd className="font-mono text-[10px]">&#8984;</kbd>+click to batch select
-          </p>
+          <div className="text-muted-foreground/60 text-xs hidden sm:flex items-center gap-4">
+            <p className="flex items-center gap-1.5">
+              <span className="flex items-center gap-0.5">
+                <ArrowUp className="size-3" />
+                <ArrowDown className="size-3" />
+                <ArrowLeft className="size-3" />
+                <ArrowRight className="size-3" />
+              </span>
+              to navigate
+            </p>
+            <p className="flex items-center gap-1.5">
+              <ListChecks className="size-3.5" />
+              <kbd className="font-mono text-[10px]">&#8984;</kbd>+click to batch select
+            </p>
+          </div>
         </div>
 
         <div
@@ -383,6 +395,7 @@ export function SoundsPage({ sounds }: SoundsPageProps) {
             onPreviewStart={onPreviewStart}
             onPreviewStop={onPreviewStop}
             onClearFilters={handleClearFilters}
+            focusRef={gridFocusRef}
           />
         </div>
       </main>

--- a/hooks/use-grid-navigation.ts
+++ b/hooks/use-grid-navigation.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+
+function getColumnCount(grid: HTMLElement): number {
+  const style = getComputedStyle(grid);
+  const columns = style.gridTemplateColumns.split(" ").length;
+  return columns || 1;
+}
+
+/**
+ * Provides arrow-key navigation for a CSS grid of focusable children.
+ *
+ * Returns a ref (attach to the grid container) and a keydown handler.
+ * Also exposes `focusFirst()` so external controls can jump into the grid.
+ */
+export function useGridNavigation() {
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  const focusFirst = useCallback(() => {
+    const grid = gridRef.current;
+    if (!grid) return;
+    const first = grid.querySelector<HTMLElement>(
+      ":scope > a, :scope > button"
+    );
+    first?.focus();
+  }, []);
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const grid = gridRef.current;
+      if (!grid) return;
+
+      const items = Array.from(
+        grid.querySelectorAll<HTMLElement>(":scope > a, :scope > button")
+      );
+      if (items.length === 0) return;
+
+      const currentIndex = items.indexOf(document.activeElement as HTMLElement);
+      if (currentIndex === -1) return;
+
+      let nextIndex: number | null = null;
+
+      switch (e.key) {
+        case "ArrowRight":
+          nextIndex =
+            currentIndex + 1 < items.length ? currentIndex + 1 : null;
+          break;
+        case "ArrowLeft":
+          nextIndex = currentIndex - 1 >= 0 ? currentIndex - 1 : null;
+          break;
+        case "ArrowDown": {
+          const cols = getColumnCount(grid);
+          nextIndex =
+            currentIndex + cols < items.length ? currentIndex + cols : null;
+          break;
+        }
+        case "ArrowUp": {
+          const cols = getColumnCount(grid);
+          nextIndex = currentIndex - cols >= 0 ? currentIndex - cols : null;
+          break;
+        }
+        default:
+          return;
+      }
+
+      if (nextIndex !== null) {
+        e.preventDefault();
+        items[nextIndex].focus();
+      }
+    },
+    []
+  );
+
+  return { gridRef, onKeyDown, focusFirst };
+}


### PR DESCRIPTION
Hey, love this project, such a good idea!

This PR adds a hook to enable keyboard navigation on the sound card grids. Users can use their arrow keys to quickly navigate around the grid. It also focuses the first card in the grid when the user hits enter from the search box. May want to play with some of the UX here, and more than happy to make edits to this PR.


https://github.com/user-attachments/assets/1b9924b2-f419-4858-8dda-32e2c25c0397

