### PR TITLE
fix: properly escape placeholder elipsis

### DIFF
--- a/components/sound-search.tsx
+++ b/components/sound-search.tsx
@@ -35,7 +35,7 @@ export function SoundSearch({ value, onChange, onEnterGrid }: SoundSearchProps) 
         name="search"
         aria-label="Search sounds"
         autoComplete="off"
-        placeholder="Search sounds\u2026"
+        placeholder="Search sounds&#x2026;"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         onKeyDown={(e) => {


### PR DESCRIPTION
Before:
<img width="438" height="146" alt="image" src="https://github.com/user-attachments/assets/e7f8eca0-b50a-4f19-8333-9c6d23308f92" />


After:
<img width="429" height="108" alt="image" src="https://github.com/user-attachments/assets/2007bce6-d5f1-4929-b734-6bc133fb284d" />
