### PR TITLE
add support for other frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,50 @@ npx shadcn add https://soundcn.xyz/r/click-soft.json
 
 Each sound is a self-contained TypeScript module with an inline base64 data URI — no external files, no runtime fetching, no CORS issues. Sounds are installed directly into your codebase, not as a dependency.
 
-Includes a `useSound` hook for playback via the Web Audio API. Zero dependencies.
+Includes a `useSound` React hook and a framework-agnostic `playSound` function for playback via the Web Audio API. Zero dependencies.
 
 ## How it works
 
 - Browse sounds at [soundcn.xyz](https://soundcn.xyz/)
-- Install any sound — it copies the `.ts` file and the `useSound` hook into your project
-- Import and play:
+- Install any sound — it copies the `.ts` file into your project
+- Pick the playback helper that fits your framework:
+
+### React
+
+```bash
+npx shadcn add https://soundcn.xyz/r/use-sound.json
+```
 
 ```tsx
 import { useSound } from "@/hooks/use-sound";
 import { clickSoftSound } from "@/sounds/click-soft";
 
 const [play] = useSound(clickSoftSound);
+```
+
+### Astro, Vue, Svelte, vanilla JS — any framework
+
+```bash
+npx shadcn add https://soundcn.xyz/r/play-sound.json
+```
+
+```ts
+import { playSound } from "@/lib/play-sound";
+import { clickSoftSound } from "@/sounds/click-soft";
+
+await playSound(clickSoftSound);
+```
+
+```astro
+---
+import { clickSoftSound } from "@/sounds/click-soft";
+---
+<button id="btn">Click me</button>
+<script>
+  import { playSound } from "@/lib/play-sound";
+  import { clickSoftSound } from "@/sounds/click-soft";
+  document.getElementById("btn")!.addEventListener("click", () => playSound(clickSoftSound));
+</script>
 ```
 
 ## License

--- a/registry.json
+++ b/registry.json
@@ -34,6 +34,21 @@
       ]
     },
     {
+      "name": "play-sound",
+      "type": "registry:lib",
+      "title": "playSound",
+      "description": "A framework-agnostic function for playing sound effects using the Web Audio API. Works with any framework (Astro, Vue, Svelte, vanilla JS) or no framework at all. Zero dependencies.",
+      "files": [
+        {
+          "path": "registry/soundcn/lib/play-sound.ts",
+          "type": "registry:lib"
+        }
+      ],
+      "categories": [
+        "lib"
+      ]
+    },
+    {
       "name": "click-8bit",
       "type": "registry:block",
       "title": "Click 8-Bit",
@@ -42,10 +57,6 @@
         {
           "path": "registry/soundcn/sounds/click-8bit/click-8bit.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -104,10 +115,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -162,10 +169,6 @@
         {
           "path": "registry/soundcn/sounds/switch-on/switch-on.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -223,10 +226,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -282,10 +281,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -339,10 +334,6 @@
         {
           "path": "registry/soundcn/sounds/success-chime/success-chime.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -401,10 +392,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -458,10 +445,6 @@
         {
           "path": "registry/soundcn/sounds/hover-tick/hover-tick.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -519,10 +502,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -575,10 +554,6 @@
         {
           "path": "registry/soundcn/sounds/coin-collect/coin-collect.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -636,10 +611,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -691,10 +662,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -743,10 +710,6 @@
         {
           "path": "registry/soundcn/sounds/back-002/back-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -802,10 +765,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -857,10 +816,6 @@
         {
           "path": "registry/soundcn/sounds/back-004/back-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -916,10 +871,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -970,10 +921,6 @@
         {
           "path": "registry/soundcn/sounds/begin/begin.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -1027,10 +974,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -1082,10 +1025,6 @@
         {
           "path": "registry/soundcn/sounds/belt-handle-2/belt-handle-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -1142,10 +1081,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -1196,10 +1131,6 @@
         {
           "path": "registry/soundcn/sounds/book-close/book-close.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -1254,10 +1185,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -1309,10 +1236,6 @@
         {
           "path": "registry/soundcn/sounds/book-flip-2/book-flip-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -1369,10 +1292,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -1427,10 +1346,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -1481,10 +1396,6 @@
         {
           "path": "registry/soundcn/sounds/book-place-1/book-place-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -1538,10 +1449,6 @@
         {
           "path": "registry/soundcn/sounds/book-place-2/book-place-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -1598,10 +1505,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -1656,10 +1559,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -1711,10 +1610,6 @@
         {
           "path": "registry/soundcn/sounds/card-fan-2/card-fan-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -1772,10 +1667,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -1828,10 +1719,6 @@
         {
           "path": "registry/soundcn/sounds/card-place-2/card-place-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -1889,10 +1776,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -1946,10 +1829,6 @@
         {
           "path": "registry/soundcn/sounds/card-place-4/card-place-4.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -2007,10 +1886,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -2063,10 +1938,6 @@
         {
           "path": "registry/soundcn/sounds/card-shove-2/card-shove-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -2124,10 +1995,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -2181,10 +2048,6 @@
         {
           "path": "registry/soundcn/sounds/card-shove-4/card-shove-4.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -2242,10 +2105,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -2296,10 +2155,6 @@
         {
           "path": "registry/soundcn/sounds/card-slide-1/card-slide-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -2353,10 +2208,6 @@
         {
           "path": "registry/soundcn/sounds/card-slide-2/card-slide-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -2413,10 +2264,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -2469,10 +2316,6 @@
         {
           "path": "registry/soundcn/sounds/card-slide-4/card-slide-4.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -2529,10 +2372,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -2585,10 +2424,6 @@
         {
           "path": "registry/soundcn/sounds/card-slide-6/card-slide-6.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -2645,10 +2480,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -2701,10 +2532,6 @@
         {
           "path": "registry/soundcn/sounds/card-slide-8/card-slide-8.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -2761,10 +2588,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -2818,10 +2641,6 @@
         {
           "path": "registry/soundcn/sounds/cards-pack-open-2/cards-pack-open-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -2880,10 +2699,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -2940,10 +2755,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -2998,10 +2809,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -3051,10 +2858,6 @@
         {
           "path": "registry/soundcn/sounds/chip-lay-1/chip-lay-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -3107,10 +2910,6 @@
         {
           "path": "registry/soundcn/sounds/chip-lay-2/chip-lay-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -3166,10 +2965,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -3221,10 +3016,6 @@
         {
           "path": "registry/soundcn/sounds/chips-collide-1/chips-collide-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -3279,10 +3070,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -3335,10 +3122,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -3389,10 +3172,6 @@
         {
           "path": "registry/soundcn/sounds/chips-collide-4/chips-collide-4.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -3448,10 +3227,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -3502,10 +3277,6 @@
         {
           "path": "registry/soundcn/sounds/chips-handle-2/chips-handle-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -3561,10 +3332,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -3616,10 +3383,6 @@
         {
           "path": "registry/soundcn/sounds/chips-handle-4/chips-handle-4.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -3675,10 +3438,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -3729,10 +3488,6 @@
         {
           "path": "registry/soundcn/sounds/chips-handle-6/chips-handle-6.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -3787,10 +3542,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -3841,10 +3592,6 @@
         {
           "path": "registry/soundcn/sounds/chips-stack-2/chips-stack-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -3899,10 +3646,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -3953,10 +3696,6 @@
         {
           "path": "registry/soundcn/sounds/chips-stack-4/chips-stack-4.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -4011,10 +3750,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -4065,10 +3800,6 @@
         {
           "path": "registry/soundcn/sounds/chips-stack-6/chips-stack-6.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -4123,10 +3854,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -4179,10 +3906,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -4231,10 +3954,6 @@
         {
           "path": "registry/soundcn/sounds/click-001/click-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -4287,10 +4006,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -4340,10 +4055,6 @@
         {
           "path": "registry/soundcn/sounds/click-003/click-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -4398,10 +4109,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -4451,10 +4158,6 @@
         {
           "path": "registry/soundcn/sounds/click-005/click-005.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -4509,10 +4212,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -4562,10 +4261,6 @@
         {
           "path": "registry/soundcn/sounds/close-002/close-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -4618,10 +4313,6 @@
         {
           "path": "registry/soundcn/sounds/close-003/close-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -4677,10 +4368,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -4734,10 +4421,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -4787,10 +4470,6 @@
         {
           "path": "registry/soundcn/sounds/cloth-2/cloth-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -4843,10 +4522,6 @@
         {
           "path": "registry/soundcn/sounds/cloth-3/cloth-3.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -4902,10 +4577,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -4958,10 +4629,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -5012,10 +4679,6 @@
         {
           "path": "registry/soundcn/sounds/cloth-belt-2/cloth-belt-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -5074,10 +4737,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -5126,10 +4785,6 @@
         {
           "path": "registry/soundcn/sounds/combo-breaker/combo-breaker.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -5181,10 +4836,6 @@
         {
           "path": "registry/soundcn/sounds/computer-noise-000/computer-noise-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -5240,10 +4891,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -5297,10 +4944,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -5352,10 +4995,6 @@
         {
           "path": "registry/soundcn/sounds/computer-noise-003/computer-noise-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -5412,10 +5051,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -5466,10 +5101,6 @@
         {
           "path": "registry/soundcn/sounds/confirmation-002/confirmation-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -5524,10 +5155,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -5578,10 +5205,6 @@
         {
           "path": "registry/soundcn/sounds/confirmation-004/confirmation-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -5637,10 +5260,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -5690,10 +5309,6 @@
         {
           "path": "registry/soundcn/sounds/creak-2/creak-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -5750,10 +5365,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -5805,10 +5416,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -5857,10 +5464,6 @@
         {
           "path": "registry/soundcn/sounds/dice-grab-1/dice-grab-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -5915,10 +5518,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -5969,10 +5568,6 @@
         {
           "path": "registry/soundcn/sounds/dice-shake-1/dice-shake-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -6028,10 +5623,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -6083,10 +5674,6 @@
         {
           "path": "registry/soundcn/sounds/dice-shake-3/dice-shake-3.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -6143,10 +5730,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -6197,10 +5780,6 @@
         {
           "path": "registry/soundcn/sounds/dice-throw-2/dice-throw-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -6256,10 +5835,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -6311,10 +5886,6 @@
         {
           "path": "registry/soundcn/sounds/die-throw-1/die-throw-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -6370,10 +5941,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -6427,10 +5994,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -6482,10 +6045,6 @@
         {
           "path": "registry/soundcn/sounds/die-throw-4/die-throw-4.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -6542,10 +6101,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -6599,10 +6154,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -6653,10 +6204,6 @@
         {
           "path": "registry/soundcn/sounds/door-close-002/door-close-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -6712,10 +6259,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -6766,10 +6309,6 @@
         {
           "path": "registry/soundcn/sounds/door-close-2/door-close-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -6825,10 +6364,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -6880,10 +6415,6 @@
         {
           "path": "registry/soundcn/sounds/door-close-4/door-close-4.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -6938,10 +6469,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -6992,10 +6519,6 @@
         {
           "path": "registry/soundcn/sounds/door-open-001/door-open-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -7050,10 +6573,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -7105,10 +6624,6 @@
         {
           "path": "registry/soundcn/sounds/door-open-1/door-open-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -7165,10 +6680,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -7221,10 +6732,6 @@
         {
           "path": "registry/soundcn/sounds/draw-knife-1/draw-knife-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -7280,10 +6787,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -7335,10 +6838,6 @@
         {
           "path": "registry/soundcn/sounds/draw-knife-3/draw-knife-3.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -7393,10 +6892,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -7446,10 +6941,6 @@
         {
           "path": "registry/soundcn/sounds/drop-002/drop-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -7503,10 +6994,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -7556,10 +7043,6 @@
         {
           "path": "registry/soundcn/sounds/drop-004/drop-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -7612,10 +7095,6 @@
         {
           "path": "registry/soundcn/sounds/drop-leather/drop-leather.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -7671,10 +7150,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -7728,10 +7203,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -7783,10 +7254,6 @@
         {
           "path": "registry/soundcn/sounds/engine-circular-002/engine-circular-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -7843,10 +7310,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -7898,10 +7361,6 @@
         {
           "path": "registry/soundcn/sounds/engine-circular-004/engine-circular-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -7958,10 +7417,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -8011,10 +7466,6 @@
         {
           "path": "registry/soundcn/sounds/error-002/error-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -8069,10 +7520,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -8122,10 +7569,6 @@
         {
           "path": "registry/soundcn/sounds/error-004/error-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -8181,10 +7624,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -8236,10 +7675,6 @@
         {
           "path": "registry/soundcn/sounds/error-006/error-006.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -8295,10 +7730,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -8350,10 +7781,6 @@
         {
           "path": "registry/soundcn/sounds/error-008/error-008.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -8408,10 +7835,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -8464,10 +7887,6 @@
         {
           "path": "registry/soundcn/sounds/explosion-crunch-001/explosion-crunch-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -8525,10 +7944,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -8580,10 +7995,6 @@
         {
           "path": "registry/soundcn/sounds/explosion-crunch-003/explosion-crunch-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -8639,10 +8050,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -8693,10 +8100,6 @@
         {
           "path": "registry/soundcn/sounds/fight/fight.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -8750,10 +8153,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -8803,10 +8202,6 @@
         {
           "path": "registry/soundcn/sounds/footstep-00/footstep-00.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -8861,10 +8256,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -8915,10 +8306,6 @@
         {
           "path": "registry/soundcn/sounds/footstep-02/footstep-02.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -8973,10 +8360,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -9027,10 +8410,6 @@
         {
           "path": "registry/soundcn/sounds/footstep-04/footstep-04.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -9085,10 +8464,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -9139,10 +8514,6 @@
         {
           "path": "registry/soundcn/sounds/footstep-06/footstep-06.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -9197,10 +8568,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -9251,10 +8618,6 @@
         {
           "path": "registry/soundcn/sounds/footstep-08/footstep-08.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -9309,10 +8672,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -9363,10 +8722,6 @@
         {
           "path": "registry/soundcn/sounds/footstep-carpet-000/footstep-carpet-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -9422,10 +8777,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -9477,10 +8828,6 @@
         {
           "path": "registry/soundcn/sounds/footstep-carpet-002/footstep-carpet-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -9536,10 +8883,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -9591,10 +8934,6 @@
         {
           "path": "registry/soundcn/sounds/footstep-carpet-004/footstep-carpet-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -9650,10 +8989,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -9705,10 +9040,6 @@
         {
           "path": "registry/soundcn/sounds/footstep-concrete-001/footstep-concrete-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -9764,10 +9095,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -9819,10 +9146,6 @@
         {
           "path": "registry/soundcn/sounds/footstep-concrete-003/footstep-concrete-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -9878,10 +9201,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -9933,10 +9252,6 @@
         {
           "path": "registry/soundcn/sounds/footstep-grass-000/footstep-grass-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -9993,10 +9308,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -10049,10 +9360,6 @@
         {
           "path": "registry/soundcn/sounds/footstep-grass-002/footstep-grass-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -10109,10 +9416,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -10165,10 +9468,6 @@
         {
           "path": "registry/soundcn/sounds/footstep-grass-004/footstep-grass-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -10225,10 +9524,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -10281,10 +9576,6 @@
         {
           "path": "registry/soundcn/sounds/footstep-snow-001/footstep-snow-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -10341,10 +9632,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -10397,10 +9684,6 @@
         {
           "path": "registry/soundcn/sounds/footstep-snow-003/footstep-snow-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -10457,10 +9740,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -10513,10 +9792,6 @@
         {
           "path": "registry/soundcn/sounds/footstep-wood-000/footstep-wood-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -10573,10 +9848,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -10629,10 +9900,6 @@
         {
           "path": "registry/soundcn/sounds/footstep-wood-002/footstep-wood-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -10689,10 +9956,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -10745,10 +10008,6 @@
         {
           "path": "registry/soundcn/sounds/footstep-wood-004/footstep-wood-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -10805,10 +10064,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -10860,10 +10115,6 @@
         {
           "path": "registry/soundcn/sounds/force-field-001/force-field-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -10919,10 +10170,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -10974,10 +10221,6 @@
         {
           "path": "registry/soundcn/sounds/force-field-003/force-field-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -11033,10 +10276,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -11088,10 +10327,6 @@
         {
           "path": "registry/soundcn/sounds/glass-001/glass-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -11146,10 +10381,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -11200,10 +10431,6 @@
         {
           "path": "registry/soundcn/sounds/glass-003/glass-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -11258,10 +10485,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -11312,10 +10535,6 @@
         {
           "path": "registry/soundcn/sounds/glass-005/glass-005.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -11370,10 +10589,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -11424,10 +10639,6 @@
         {
           "path": "registry/soundcn/sounds/glitch-001/glitch-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -11482,10 +10693,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -11536,10 +10743,6 @@
         {
           "path": "registry/soundcn/sounds/glitch-003/glitch-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -11594,10 +10797,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -11650,10 +10849,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -11704,10 +10899,6 @@
         {
           "path": "registry/soundcn/sounds/handle-coins-2/handle-coins-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -11763,10 +10954,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -11818,10 +11005,6 @@
         {
           "path": "registry/soundcn/sounds/handle-small-leather-2/handle-small-leather-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -11878,10 +11061,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -11932,10 +11111,6 @@
         {
           "path": "registry/soundcn/sounds/high-up/high-up.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -11990,10 +11165,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -12043,10 +11214,6 @@
         {
           "path": "registry/soundcn/sounds/impact-bell-heavy-000/impact-bell-heavy-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -12103,10 +11270,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -12159,10 +11322,6 @@
         {
           "path": "registry/soundcn/sounds/impact-bell-heavy-002/impact-bell-heavy-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -12219,10 +11378,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -12275,10 +11430,6 @@
         {
           "path": "registry/soundcn/sounds/impact-bell-heavy-004/impact-bell-heavy-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -12335,10 +11486,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -12391,10 +11538,6 @@
         {
           "path": "registry/soundcn/sounds/impact-generic-light-001/impact-generic-light-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -12451,10 +11594,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -12507,10 +11646,6 @@
         {
           "path": "registry/soundcn/sounds/impact-generic-light-003/impact-generic-light-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -12567,10 +11702,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -12623,10 +11754,6 @@
         {
           "path": "registry/soundcn/sounds/impact-glass-heavy-000/impact-glass-heavy-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -12683,10 +11810,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -12739,10 +11862,6 @@
         {
           "path": "registry/soundcn/sounds/impact-glass-heavy-002/impact-glass-heavy-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -12799,10 +11918,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -12855,10 +11970,6 @@
         {
           "path": "registry/soundcn/sounds/impact-glass-heavy-004/impact-glass-heavy-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -12915,10 +12026,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -12971,10 +12078,6 @@
         {
           "path": "registry/soundcn/sounds/impact-glass-light-001/impact-glass-light-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -13031,10 +12134,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -13088,10 +12187,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -13143,10 +12238,6 @@
         {
           "path": "registry/soundcn/sounds/impact-glass-light-004/impact-glass-light-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -13203,10 +12294,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -13259,10 +12346,6 @@
         {
           "path": "registry/soundcn/sounds/impact-glass-medium-001/impact-glass-medium-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -13319,10 +12402,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -13375,10 +12454,6 @@
         {
           "path": "registry/soundcn/sounds/impact-glass-medium-003/impact-glass-medium-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -13435,10 +12510,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -13493,10 +12564,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -13548,10 +12615,6 @@
         {
           "path": "registry/soundcn/sounds/impact-metal-001/impact-metal-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -13608,10 +12671,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -13663,10 +12722,6 @@
         {
           "path": "registry/soundcn/sounds/impact-metal-003/impact-metal-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -13722,10 +12777,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -13777,10 +12828,6 @@
         {
           "path": "registry/soundcn/sounds/impact-metal-heavy-000/impact-metal-heavy-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -13837,10 +12884,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -13893,10 +12936,6 @@
         {
           "path": "registry/soundcn/sounds/impact-metal-heavy-002/impact-metal-heavy-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -13953,10 +12992,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -14009,10 +13044,6 @@
         {
           "path": "registry/soundcn/sounds/impact-metal-heavy-004/impact-metal-heavy-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -14069,10 +13100,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -14125,10 +13152,6 @@
         {
           "path": "registry/soundcn/sounds/impact-metal-light-001/impact-metal-light-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -14185,10 +13208,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -14241,10 +13260,6 @@
         {
           "path": "registry/soundcn/sounds/impact-metal-light-003/impact-metal-light-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -14302,10 +13317,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -14358,10 +13369,6 @@
         {
           "path": "registry/soundcn/sounds/impact-metal-medium-000/impact-metal-medium-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -14418,10 +13425,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -14474,10 +13477,6 @@
         {
           "path": "registry/soundcn/sounds/impact-metal-medium-002/impact-metal-medium-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -14534,10 +13533,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -14590,10 +13585,6 @@
         {
           "path": "registry/soundcn/sounds/impact-metal-medium-004/impact-metal-medium-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -14650,10 +13641,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -14705,10 +13692,6 @@
         {
           "path": "registry/soundcn/sounds/impact-mining-001/impact-mining-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -14764,10 +13747,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -14819,10 +13798,6 @@
         {
           "path": "registry/soundcn/sounds/impact-mining-003/impact-mining-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -14877,10 +13852,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -14932,10 +13903,6 @@
         {
           "path": "registry/soundcn/sounds/impact-plank-medium-000/impact-plank-medium-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -14992,10 +13959,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -15048,10 +14011,6 @@
         {
           "path": "registry/soundcn/sounds/impact-plank-medium-002/impact-plank-medium-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -15108,10 +14067,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -15164,10 +14119,6 @@
         {
           "path": "registry/soundcn/sounds/impact-plank-medium-004/impact-plank-medium-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -15224,10 +14175,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -15279,10 +14226,6 @@
         {
           "path": "registry/soundcn/sounds/impact-plate-heavy-001/impact-plate-heavy-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -15339,10 +14282,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -15395,10 +14334,6 @@
         {
           "path": "registry/soundcn/sounds/impact-plate-heavy-003/impact-plate-heavy-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -15455,10 +14390,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -15511,10 +14442,6 @@
         {
           "path": "registry/soundcn/sounds/impact-plate-light-000/impact-plate-light-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -15571,10 +14498,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -15629,10 +14552,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -15685,10 +14604,6 @@
         {
           "path": "registry/soundcn/sounds/impact-plate-light-003/impact-plate-light-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -15746,10 +14661,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -15804,10 +14715,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -15859,10 +14766,6 @@
         {
           "path": "registry/soundcn/sounds/impact-plate-medium-001/impact-plate-medium-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -15919,10 +14822,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -15975,10 +14874,6 @@
         {
           "path": "registry/soundcn/sounds/impact-plate-medium-003/impact-plate-medium-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -16035,10 +14930,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -16091,10 +14982,6 @@
         {
           "path": "registry/soundcn/sounds/impact-punch-heavy-000/impact-punch-heavy-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -16151,10 +15038,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -16207,10 +15090,6 @@
         {
           "path": "registry/soundcn/sounds/impact-punch-heavy-002/impact-punch-heavy-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -16267,10 +15146,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -16325,10 +15200,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -16380,10 +15251,6 @@
         {
           "path": "registry/soundcn/sounds/impact-punch-medium-000/impact-punch-medium-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -16440,10 +15307,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -16496,10 +15359,6 @@
         {
           "path": "registry/soundcn/sounds/impact-punch-medium-002/impact-punch-medium-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -16556,10 +15415,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -16612,10 +15467,6 @@
         {
           "path": "registry/soundcn/sounds/impact-punch-medium-004/impact-punch-medium-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -16672,10 +15523,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -16730,10 +15577,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -16785,10 +15628,6 @@
         {
           "path": "registry/soundcn/sounds/impact-soft-heavy-002/impact-soft-heavy-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -16845,10 +15684,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -16901,10 +15736,6 @@
         {
           "path": "registry/soundcn/sounds/impact-soft-heavy-004/impact-soft-heavy-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -16961,10 +15792,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -17017,10 +15844,6 @@
         {
           "path": "registry/soundcn/sounds/impact-soft-medium-001/impact-soft-medium-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -17077,10 +15900,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -17133,10 +15952,6 @@
         {
           "path": "registry/soundcn/sounds/impact-soft-medium-003/impact-soft-medium-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -17193,10 +16008,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -17251,10 +16062,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -17307,10 +16114,6 @@
         {
           "path": "registry/soundcn/sounds/impact-tin-medium-001/impact-tin-medium-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -17368,10 +16171,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -17424,10 +16223,6 @@
         {
           "path": "registry/soundcn/sounds/impact-tin-medium-003/impact-tin-medium-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -17485,10 +16280,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -17541,10 +16332,6 @@
         {
           "path": "registry/soundcn/sounds/impact-wood-heavy-000/impact-wood-heavy-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -17602,10 +16389,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -17661,10 +16444,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -17717,10 +16496,6 @@
         {
           "path": "registry/soundcn/sounds/impact-wood-heavy-003/impact-wood-heavy-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -17778,10 +16553,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -17835,10 +16606,6 @@
         {
           "path": "registry/soundcn/sounds/impact-wood-light-000/impact-wood-light-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -17896,10 +16663,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -17953,10 +16716,6 @@
         {
           "path": "registry/soundcn/sounds/impact-wood-light-002/impact-wood-light-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -18014,10 +16773,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -18071,10 +16826,6 @@
         {
           "path": "registry/soundcn/sounds/impact-wood-light-004/impact-wood-light-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -18133,10 +16884,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -18190,10 +16937,6 @@
         {
           "path": "registry/soundcn/sounds/impact-wood-medium-001/impact-wood-medium-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -18252,10 +16995,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -18309,10 +17048,6 @@
         {
           "path": "registry/soundcn/sounds/impact-wood-medium-003/impact-wood-medium-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -18370,10 +17105,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -18427,10 +17158,6 @@
         {
           "path": "registry/soundcn/sounds/its-a-tie/its-a-tie.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -18487,10 +17214,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -18545,10 +17268,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -18601,10 +17320,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-hit-02/jingles-hit-02.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -18662,10 +17377,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -18718,10 +17429,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-hit-04/jingles-hit-04.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -18779,10 +17486,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -18835,10 +17538,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-hit-06/jingles-hit-06.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -18896,10 +17595,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -18953,10 +17648,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-hit-08/jingles-hit-08.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -19013,10 +17704,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -19071,10 +17758,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -19127,10 +17810,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-hit-11/jingles-hit-11.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -19189,10 +17868,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -19246,10 +17921,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-hit-13/jingles-hit-13.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -19307,10 +17978,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -19364,10 +18031,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-hit-15/jingles-hit-15.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -19426,10 +18089,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -19483,10 +18142,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-nes-00/jingles-nes-00.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -19544,10 +18199,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -19602,10 +18253,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-nes-02/jingles-nes-02.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -19665,10 +18312,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -19724,10 +18367,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-nes-04/jingles-nes-04.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -19788,10 +18427,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -19847,10 +18482,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-nes-06/jingles-nes-06.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -19909,10 +18540,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -19968,10 +18595,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-nes-08/jingles-nes-08.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -20032,10 +18655,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -20091,10 +18710,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-nes-10/jingles-nes-10.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -20156,10 +18771,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -20210,10 +18821,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-nes-12/jingles-nes-12.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -20269,10 +18876,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -20324,10 +18927,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-nes-14/jingles-nes-14.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -20383,10 +18982,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -20437,10 +19032,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-nes-16/jingles-nes-16.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -20496,10 +19087,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -20551,10 +19138,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-pizzi-01/jingles-pizzi-01.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -20609,10 +19192,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -20664,10 +19243,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -20717,10 +19292,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-pizzi-04/jingles-pizzi-04.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -20775,10 +19346,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -20828,10 +19395,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-pizzi-06/jingles-pizzi-06.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -20885,10 +19448,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -20937,10 +19496,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-pizzi-08/jingles-pizzi-08.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -20995,10 +19550,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -21049,10 +19600,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-pizzi-10/jingles-pizzi-10.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -21106,10 +19653,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -21161,10 +19704,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -21213,10 +19752,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-pizzi-13/jingles-pizzi-13.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -21270,10 +19805,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -21322,10 +19853,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-pizzi-15/jingles-pizzi-15.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -21379,10 +19906,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -21432,10 +19955,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-sax-00/jingles-sax-00.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -21490,10 +20009,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -21543,10 +20058,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-sax-02/jingles-sax-02.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -21601,10 +20112,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -21655,10 +20162,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-sax-04/jingles-sax-04.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -21713,10 +20216,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -21768,10 +20267,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -21821,10 +20316,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-sax-07/jingles-sax-07.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -21879,10 +20370,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -21934,10 +20421,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -21986,10 +20469,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-sax-10/jingles-sax-10.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -22043,10 +20522,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -22095,10 +20570,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-sax-12/jingles-sax-12.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -22152,10 +20623,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -22207,10 +20674,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -22259,10 +20722,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-sax-15/jingles-sax-15.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -22316,10 +20775,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -22368,10 +20823,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-steel-00/jingles-steel-00.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -22426,10 +20877,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -22478,10 +20925,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-steel-02/jingles-steel-02.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -22534,10 +20977,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -22585,10 +21024,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-steel-04/jingles-steel-04.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -22641,10 +21076,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -22693,10 +21124,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-steel-06/jingles-steel-06.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -22750,10 +21177,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -22803,10 +21226,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-steel-08/jingles-steel-08.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -22859,10 +21278,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -22911,10 +21326,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-steel-10/jingles-steel-10.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -22969,10 +21380,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -23023,10 +21430,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-steel-12/jingles-steel-12.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -23081,10 +21484,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -23135,10 +21534,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-steel-14/jingles-steel-14.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -23193,10 +21588,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -23247,10 +21638,6 @@
         {
           "path": "registry/soundcn/sounds/jingles-steel-16/jingles-steel-16.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -23305,10 +21692,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -23357,10 +21740,6 @@
         {
           "path": "registry/soundcn/sounds/kill-him/kill-him.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -23413,10 +21792,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -23465,10 +21840,6 @@
         {
           "path": "registry/soundcn/sounds/knife-slice/knife-slice.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -23520,10 +21891,6 @@
         {
           "path": "registry/soundcn/sounds/knife-slice-2/knife-slice-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -23578,10 +21945,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -23631,10 +21994,6 @@
         {
           "path": "registry/soundcn/sounds/laser-2/laser-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -23689,10 +22048,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -23745,10 +22100,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -23799,10 +22150,6 @@
         {
           "path": "registry/soundcn/sounds/laser-5/laser-5.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -23858,10 +22205,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -23912,10 +22255,6 @@
         {
           "path": "registry/soundcn/sounds/laser-7/laser-7.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -23971,10 +22310,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -24026,10 +22361,6 @@
         {
           "path": "registry/soundcn/sounds/laser-9/laser-9.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -24085,10 +22416,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -24141,10 +22468,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -24195,10 +22518,6 @@
         {
           "path": "registry/soundcn/sounds/laser-large-002/laser-large-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -24254,10 +22573,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -24308,10 +22623,6 @@
         {
           "path": "registry/soundcn/sounds/laser-large-004/laser-large-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -24367,10 +22678,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -24421,10 +22728,6 @@
         {
           "path": "registry/soundcn/sounds/laser-retro-001/laser-retro-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -24480,10 +22783,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -24534,10 +22833,6 @@
         {
           "path": "registry/soundcn/sounds/laser-retro-003/laser-retro-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -24592,10 +22887,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -24646,10 +22937,6 @@
         {
           "path": "registry/soundcn/sounds/laser-small-000/laser-small-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -24704,10 +22991,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -24758,10 +23041,6 @@
         {
           "path": "registry/soundcn/sounds/laser-small-002/laser-small-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -24816,10 +23095,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -24870,10 +23145,6 @@
         {
           "path": "registry/soundcn/sounds/laser-small-004/laser-small-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -24928,10 +23199,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -24980,10 +23247,6 @@
         {
           "path": "registry/soundcn/sounds/low-down/low-down.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -25035,10 +23298,6 @@
         {
           "path": "registry/soundcn/sounds/low-frequency-explosion-000/low-frequency-explosion-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -25094,10 +23353,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -25151,10 +23406,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -25203,10 +23454,6 @@
         {
           "path": "registry/soundcn/sounds/low-three-tone/low-three-tone.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -25260,10 +23507,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -25313,10 +23556,6 @@
         {
           "path": "registry/soundcn/sounds/maximize-002/maximize-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -25369,10 +23608,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -25423,10 +23658,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -25475,10 +23706,6 @@
         {
           "path": "registry/soundcn/sounds/maximize-005/maximize-005.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -25532,10 +23759,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -25585,10 +23808,6 @@
         {
           "path": "registry/soundcn/sounds/maximize-007/maximize-007.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -25641,10 +23860,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -25694,10 +23909,6 @@
         {
           "path": "registry/soundcn/sounds/maximize-009/maximize-009.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -25752,10 +23963,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -25805,10 +24012,6 @@
         {
           "path": "registry/soundcn/sounds/metal-latch/metal-latch.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -25861,10 +24064,6 @@
         {
           "path": "registry/soundcn/sounds/metal-pot-1/metal-pot-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -25920,10 +24119,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -25974,10 +24169,6 @@
         {
           "path": "registry/soundcn/sounds/metal-pot-3/metal-pot-3.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -26031,10 +24222,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -26084,10 +24271,6 @@
         {
           "path": "registry/soundcn/sounds/minimize-002/minimize-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -26141,10 +24324,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -26194,10 +24373,6 @@
         {
           "path": "registry/soundcn/sounds/minimize-004/minimize-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -26251,10 +24426,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -26306,10 +24477,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -26358,10 +24525,6 @@
         {
           "path": "registry/soundcn/sounds/minimize-007/minimize-007.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -26415,10 +24578,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -26470,10 +24629,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -26523,10 +24678,6 @@
         {
           "path": "registry/soundcn/sounds/multi-kill/multi-kill.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -26581,10 +24732,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -26634,10 +24781,6 @@
         {
           "path": "registry/soundcn/sounds/open-002/open-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -26690,10 +24833,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -26742,10 +24881,6 @@
         {
           "path": "registry/soundcn/sounds/open-004/open-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -26797,10 +24932,6 @@
         {
           "path": "registry/soundcn/sounds/pep-sound-1/pep-sound-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -26856,10 +24987,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -26911,10 +25038,6 @@
         {
           "path": "registry/soundcn/sounds/pep-sound-3/pep-sound-3.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -26969,10 +25092,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -27025,10 +25144,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -27078,10 +25193,6 @@
         {
           "path": "registry/soundcn/sounds/phase-jump-1/phase-jump-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -27136,10 +25247,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -27190,10 +25297,6 @@
         {
           "path": "registry/soundcn/sounds/phase-jump-3/phase-jump-3.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -27249,10 +25352,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -27303,10 +25402,6 @@
         {
           "path": "registry/soundcn/sounds/phase-jump-5/phase-jump-5.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -27361,10 +25456,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -27414,10 +25505,6 @@
         {
           "path": "registry/soundcn/sounds/phaser-down-2/phaser-down-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -27471,10 +25558,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -27525,10 +25608,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -27577,10 +25656,6 @@
         {
           "path": "registry/soundcn/sounds/phaser-up-2/phaser-up-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -27634,10 +25709,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -27687,10 +25758,6 @@
         {
           "path": "registry/soundcn/sounds/phaser-up-4/phaser-up-4.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -27744,10 +25811,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -27797,10 +25860,6 @@
         {
           "path": "registry/soundcn/sounds/phaser-up-6/phaser-up-6.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -27853,10 +25912,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -27905,10 +25960,6 @@
         {
           "path": "registry/soundcn/sounds/player-1/player-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -27960,10 +26011,6 @@
         {
           "path": "registry/soundcn/sounds/player-2/player-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -28018,10 +26065,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -28073,10 +26116,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -28125,10 +26164,6 @@
         {
           "path": "registry/soundcn/sounds/power-up-1/power-up-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -28182,10 +26217,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -28235,10 +26266,6 @@
         {
           "path": "registry/soundcn/sounds/power-up-11/power-up-11.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -28292,10 +26319,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -28345,10 +26368,6 @@
         {
           "path": "registry/soundcn/sounds/power-up-2/power-up-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -28402,10 +26421,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -28455,10 +26470,6 @@
         {
           "path": "registry/soundcn/sounds/power-up-4/power-up-4.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -28514,10 +26525,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -28569,10 +26576,6 @@
         {
           "path": "registry/soundcn/sounds/power-up-6/power-up-6.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -28628,10 +26631,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -28683,10 +26682,6 @@
         {
           "path": "registry/soundcn/sounds/power-up-8/power-up-8.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -28742,10 +26737,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -28799,10 +26790,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -28852,10 +26839,6 @@
         {
           "path": "registry/soundcn/sounds/question-001/question-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -28908,10 +26891,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -28960,10 +26939,6 @@
         {
           "path": "registry/soundcn/sounds/question-003/question-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -29016,10 +26991,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -29068,10 +27039,6 @@
         {
           "path": "registry/soundcn/sounds/round-1/round-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -29124,10 +27091,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -29176,10 +27139,6 @@
         {
           "path": "registry/soundcn/sounds/round-3/round-3.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -29232,10 +27191,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -29286,10 +27241,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -29338,10 +27289,6 @@
         {
           "path": "registry/soundcn/sounds/scratch-001/scratch-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -29395,10 +27342,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -29448,10 +27391,6 @@
         {
           "path": "registry/soundcn/sounds/scratch-003/scratch-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -29505,10 +27444,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -29558,10 +27493,6 @@
         {
           "path": "registry/soundcn/sounds/scratch-005/scratch-005.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -29615,10 +27546,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -29668,10 +27595,6 @@
         {
           "path": "registry/soundcn/sounds/scroll-002/scroll-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -29725,10 +27648,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -29778,10 +27697,6 @@
         {
           "path": "registry/soundcn/sounds/scroll-004/scroll-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -29835,10 +27750,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -29888,10 +27799,6 @@
         {
           "path": "registry/soundcn/sounds/select-001/select-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -29946,10 +27853,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -30000,10 +27903,6 @@
         {
           "path": "registry/soundcn/sounds/select-003/select-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -30058,10 +27957,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -30112,10 +28007,6 @@
         {
           "path": "registry/soundcn/sounds/select-005/select-005.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -30170,10 +28061,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -30224,10 +28111,6 @@
         {
           "path": "registry/soundcn/sounds/select-007/select-007.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -30282,10 +28165,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -30336,10 +28215,6 @@
         {
           "path": "registry/soundcn/sounds/slime-000/slime-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -30394,10 +28269,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -30448,10 +28319,6 @@
         {
           "path": "registry/soundcn/sounds/space-engine-000/space-engine-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -30507,10 +28374,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -30562,10 +28425,6 @@
         {
           "path": "registry/soundcn/sounds/space-engine-002/space-engine-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -30621,10 +28480,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -30676,10 +28531,6 @@
         {
           "path": "registry/soundcn/sounds/space-engine-large-000/space-engine-large-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -30737,10 +28588,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -30794,10 +28641,6 @@
         {
           "path": "registry/soundcn/sounds/space-engine-large-002/space-engine-large-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -30855,10 +28698,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -30912,10 +28751,6 @@
         {
           "path": "registry/soundcn/sounds/space-engine-large-004/space-engine-large-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -30973,10 +28808,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -31030,10 +28861,6 @@
         {
           "path": "registry/soundcn/sounds/space-engine-low-001/space-engine-low-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -31091,10 +28918,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -31148,10 +28971,6 @@
         {
           "path": "registry/soundcn/sounds/space-engine-low-003/space-engine-low-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -31209,10 +29028,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -31266,10 +29081,6 @@
         {
           "path": "registry/soundcn/sounds/space-engine-small-000/space-engine-small-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -31326,10 +29137,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -31382,10 +29189,6 @@
         {
           "path": "registry/soundcn/sounds/space-engine-small-002/space-engine-small-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -31442,10 +29245,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -31498,10 +29297,6 @@
         {
           "path": "registry/soundcn/sounds/space-engine-small-004/space-engine-small-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -31558,10 +29353,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -31613,10 +29404,6 @@
         {
           "path": "registry/soundcn/sounds/space-trash-2/space-trash-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -31672,10 +29459,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -31727,10 +29510,6 @@
         {
           "path": "registry/soundcn/sounds/space-trash-4/space-trash-4.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -31786,10 +29565,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -31841,10 +29616,6 @@
         {
           "path": "registry/soundcn/sounds/story-mode/story-mode.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -31899,10 +29670,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -31955,10 +29722,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -32008,10 +29771,6 @@
         {
           "path": "registry/soundcn/sounds/switch-001/switch-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -32066,10 +29825,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -32120,10 +29875,6 @@
         {
           "path": "registry/soundcn/sounds/switch-003/switch-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -32178,10 +29929,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -32232,10 +29979,6 @@
         {
           "path": "registry/soundcn/sounds/switch-005/switch-005.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -32290,10 +30033,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -32346,10 +30085,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -32400,10 +30135,6 @@
         {
           "path": "registry/soundcn/sounds/three-tone-1/three-tone-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -32459,10 +30190,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -32514,10 +30241,6 @@
         {
           "path": "registry/soundcn/sounds/thruster-fire-000/thruster-fire-000.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -32573,10 +30296,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -32628,10 +30347,6 @@
         {
           "path": "registry/soundcn/sounds/thruster-fire-002/thruster-fire-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -32687,10 +30402,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -32742,10 +30453,6 @@
         {
           "path": "registry/soundcn/sounds/thruster-fire-004/thruster-fire-004.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -32801,10 +30508,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -32855,10 +30558,6 @@
         {
           "path": "registry/soundcn/sounds/tick-002/tick-002.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -32913,10 +30612,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -32969,10 +30664,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -33022,10 +30713,6 @@
         {
           "path": "registry/soundcn/sounds/tie-breaker/tie-breaker.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -33080,10 +30767,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -33133,10 +30816,6 @@
         {
           "path": "registry/soundcn/sounds/toggle-001/toggle-001.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -33192,10 +30871,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -33247,10 +30922,6 @@
         {
           "path": "registry/soundcn/sounds/toggle-003/toggle-003.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -33306,10 +30977,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -33363,10 +31030,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -33418,10 +31081,6 @@
         {
           "path": "registry/soundcn/sounds/two-tone-1/two-tone-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -33478,10 +31137,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -33534,10 +31189,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-1/voiceover-pack-female-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -33593,10 +31244,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -33648,10 +31295,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-2/voiceover-pack-female-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -33707,10 +31350,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -33762,10 +31401,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-4/voiceover-pack-female-4.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -33821,10 +31456,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -33876,10 +31507,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-6/voiceover-pack-female-6.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -33935,10 +31562,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -33990,10 +31613,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-8/voiceover-pack-female-8.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -34049,10 +31668,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -34104,10 +31719,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-congratulations/voiceover-pack-female-congratulations.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -34164,10 +31775,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -34220,10 +31827,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-final-round/voiceover-pack-female-final-round.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -34279,10 +31882,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-game-over/voiceover-pack-female-game-over.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -34341,10 +31940,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -34398,10 +31993,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-hurry-up/voiceover-pack-female-hurry-up.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -34458,10 +32049,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-its-a-tie/voiceover-pack-female-its-a-tie.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -34521,10 +32108,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -34577,10 +32160,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-level-up/voiceover-pack-female-level-up.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -34639,10 +32218,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -34697,10 +32272,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-mission-failed/voiceover-pack-female-mission-failed.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -34759,10 +32330,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -34817,10 +32384,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-objective-achieved/voiceover-pack-female-objective-achieved.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -34879,10 +32442,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -34937,10 +32496,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-ready/voiceover-pack-female-ready.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -34998,10 +32553,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -35055,10 +32606,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-set/voiceover-pack-female-set.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -35116,10 +32663,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -35174,10 +32717,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-war-call-for-backup/voiceover-pack-female-war-call-for-backup.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -35238,10 +32777,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -35297,10 +32832,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-war-fire-in-the-hole/voiceover-pack-female-war-fire-in-the-hole.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -35362,10 +32893,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -35421,10 +32948,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-war-go-go-go/voiceover-pack-female-war-go-go-go.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -35485,10 +33008,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -35546,10 +33065,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -35603,10 +33118,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-war-reloading/voiceover-pack-female-war-reloading.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -35665,10 +33176,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -35725,10 +33232,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -35782,10 +33285,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-war-target-destroyed/voiceover-pack-female-war-target-destroyed.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -35844,10 +33343,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -35903,10 +33398,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-war-watch-my-back/voiceover-pack-female-war-watch-my-back.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -35967,10 +33458,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -36023,10 +33510,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-female-you-lose/voiceover-pack-female-you-lose.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -36085,10 +33568,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -36145,10 +33624,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -36201,10 +33676,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-fighter-10/voiceover-pack-fighter-10.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -36261,10 +33732,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -36317,10 +33784,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-fighter-3/voiceover-pack-fighter-3.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -36377,10 +33840,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -36433,10 +33892,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-fighter-5/voiceover-pack-fighter-5.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -36493,10 +33948,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -36549,10 +34000,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-fighter-7/voiceover-pack-fighter-7.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -36609,10 +34056,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -36665,10 +34108,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-fighter-9/voiceover-pack-fighter-9.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -36725,10 +34164,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -36783,10 +34218,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-fighter-game-over/voiceover-pack-fighter-game-over.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -36846,10 +34277,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -36904,10 +34331,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-fighter-you-lose/voiceover-pack-fighter-you-lose.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -36967,10 +34390,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -37028,10 +34447,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -37083,10 +34498,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-10/voiceover-pack-male-10.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -37141,10 +34552,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-2/voiceover-pack-male-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -37202,10 +34609,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -37259,10 +34662,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-4/voiceover-pack-male-4.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -37319,10 +34718,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -37375,10 +34770,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-6/voiceover-pack-male-6.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -37435,10 +34826,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -37491,10 +34878,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-8/voiceover-pack-male-8.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -37551,10 +34934,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -37607,10 +34986,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-congratulations/voiceover-pack-male-congratulations.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -37667,10 +35042,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -37723,10 +35094,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-final-round/voiceover-pack-male-final-round.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -37782,10 +35149,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-game-over/voiceover-pack-male-game-over.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -37844,10 +35207,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -37901,10 +35260,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-hurry-up/voiceover-pack-male-hurry-up.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -37963,10 +35318,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -38023,10 +35374,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -38079,10 +35426,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-level-up/voiceover-pack-male-level-up.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -38138,10 +35481,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-mission-completed/voiceover-pack-male-mission-completed.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -38200,10 +35539,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -38260,10 +35595,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -38317,10 +35648,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-objective-achieved/voiceover-pack-male-objective-achieved.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -38379,10 +35706,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -38439,10 +35762,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -38495,10 +35814,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-round/voiceover-pack-male-round.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -38555,10 +35870,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -38611,10 +35922,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-time-over/voiceover-pack-male-time-over.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -38671,10 +35978,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-war-call-for-backup/voiceover-pack-male-war-call-for-backup.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -38734,10 +36037,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -38793,10 +36092,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-war-fire-in-the-hole/voiceover-pack-male-war-fire-in-the-hole.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -38858,10 +36153,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -38917,10 +36208,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-war-go-go-go/voiceover-pack-male-war-go-go-go.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -38982,10 +36269,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -39041,10 +36324,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-war-medic/voiceover-pack-male-war-medic.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -39103,10 +36382,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -39160,10 +36435,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-war-rpg/voiceover-pack-male-war-rpg.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -39222,10 +36493,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -39279,10 +36546,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-war-target-destroyed/voiceover-pack-male-war-target-destroyed.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -39341,10 +36604,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -39399,10 +36658,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-war-watch-my-back/voiceover-pack-male-war-watch-my-back.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -39462,10 +36717,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -39520,10 +36771,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -39576,10 +36823,6 @@
         {
           "path": "registry/soundcn/sounds/voiceover-pack-male-you-win/voiceover-pack-male-you-win.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -39637,10 +36880,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -39691,10 +36930,6 @@
         {
           "path": "registry/soundcn/sounds/war-suppressing-fire/war-suppressing-fire.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -39750,10 +36985,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -39807,10 +37038,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -39859,10 +37086,6 @@
         {
           "path": "registry/soundcn/sounds/zap-1/zap-1.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -39917,10 +37140,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -39971,10 +37190,6 @@
         {
           "path": "registry/soundcn/sounds/zap-three-tone-down/zap-three-tone-down.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",
@@ -40031,10 +37246,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -40089,10 +37300,6 @@
           "type": "registry:lib"
         },
         {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
-        },
-        {
           "path": "registry/soundcn/lib/sound-types.ts",
           "type": "registry:lib"
         }
@@ -40143,10 +37350,6 @@
         {
           "path": "registry/soundcn/sounds/zap-two-tone-2/zap-two-tone-2.ts",
           "type": "registry:lib"
-        },
-        {
-          "path": "registry/soundcn/hooks/use-sound.ts",
-          "type": "registry:hook"
         },
         {
           "path": "registry/soundcn/lib/sound-types.ts",

--- a/registry/soundcn/lib/play-sound.ts
+++ b/registry/soundcn/lib/play-sound.ts
@@ -1,0 +1,54 @@
+import type { SoundAsset } from "@/lib/sound-types";
+
+let audioContext: AudioContext | null = null;
+
+function getAudioContext(): AudioContext {
+  if (!audioContext) {
+    audioContext = new AudioContext();
+  }
+  return audioContext;
+}
+
+const bufferCache = new Map<string, AudioBuffer>();
+
+async function decodeAudioData(dataUri: string): Promise<AudioBuffer> {
+  const cached = bufferCache.get(dataUri);
+  if (cached) return cached;
+
+  const ctx = getAudioContext();
+  const base64 = dataUri.split(",")[1];
+  const binaryString = atob(base64);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+
+  const audioBuffer = await ctx.decodeAudioData(bytes.buffer.slice(0));
+  bufferCache.set(dataUri, audioBuffer);
+  return audioBuffer;
+}
+
+export async function playSound(
+  sound: SoundAsset,
+  options: { volume?: number; playbackRate?: number } = {}
+): Promise<AudioBufferSourceNode> {
+  const ctx = getAudioContext();
+
+  if (ctx.state === "suspended") {
+    await ctx.resume();
+  }
+
+  const buffer = await decodeAudioData(sound.dataUri);
+  const source = ctx.createBufferSource();
+  const gain = ctx.createGain();
+
+  source.buffer = buffer;
+  source.playbackRate.value = options.playbackRate ?? 1;
+  gain.gain.value = options.volume ?? 1;
+
+  source.connect(gain);
+  gain.connect(ctx.destination);
+  source.start(0);
+
+  return source;
+}


### PR DESCRIPTION
Framework-agnostic sound playback

Sounds are now decoupled from React. Previously, every sound install bundled the useSound React hook making the registry unusable outside React projects.

Sounds are plain TypeScript data. Users choose their playback helper:
`use-sound.json` for React projects (hook with state, volume, pause/stop)
`play-sound.json` for everything else (Astro, Vue, Svelte, vanilla JS)

No breaking changes, React users just install use-sound separately alongside their sounds.